### PR TITLE
Encoding correction and http response correctly closing

### DIFF
--- a/custom_components/oekofen_pellematic_compact/__init__.py
+++ b/custom_components/oekofen_pellematic_compact/__init__.py
@@ -155,7 +155,16 @@ class PellematicHub:
 def fetch_data(url: str):
     """Get data"""
     req = urllib.request.Request(url)
-    response = urllib.request.urlopen(req).read().decode("utf-8", "ignore")
-    response.replace("L_statetext:", "L_statetext\":")  # Hotfix for pellematic update 4.02 (invalid json)
-    result = json.loads(response)
+    response = None
+    str_response = None
+    try:
+        response = urllib.request.urlopen(req)
+        str_response = response.read().decode("iso-8859-1", "ignore")
+    finally:
+        if response is not None:
+            response.close()
+
+    # Hotfix for pellematic update 4.02 (invalid json)
+    str_response.replace("L_statetext:", 'L_statetext":')
+    result = json.loads(str_response)
     return result


### PR DESCRIPTION
Hi,
You did a great job with this integration of pellematic data.
I use it now and it replaces all the yaml configuration using the REST integration.
The correct encoding of the REST result for french specific characters is iso-8859-1 and not utf-8 so I corrected it. 
I also implemented a close on the request in order to free ressources. It resolves these types of error after a few hour of polling without homeassistant restart :

> 2023-03-16 23:36:22.656 ERROR (MainThread) [custom_components.oekofen_pellematic_compact] Error reading pellematic data
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.10/urllib/request.py", line 1348, in do_open
>     h.request(req.get_method(), req.selector, req.data, headers,
>   File "/usr/local/lib/python3.10/http/client.py", line 1282, in request
>     self._send_request(method, url, body, headers, encode_chunked)
>   File "/usr/local/lib/python3.10/http/client.py", line 1328, in _send_request
>     self.endheaders(body, encode_chunked=encode_chunked)
>   File "/usr/local/lib/python3.10/http/client.py", line 1277, in endheaders
>     self._send_output(message_body, encode_chunked=encode_chunked)
>   File "/usr/local/lib/python3.10/http/client.py", line 1037, in _send_output
>     self.send(msg)
>   File "/usr/local/lib/python3.10/http/client.py", line 975, in send
>     self.connect()
>   File "/usr/local/lib/python3.10/http/client.py", line 941, in connect
>     self.sock = self._create_connection(
>   File "/usr/local/lib/python3.10/socket.py", line 845, in create_connection
>     raise err
>   File "/usr/local/lib/python3.10/socket.py", line 833, in create_connection
>     sock.connect(sa)
> TimeoutError: [Errno 110] Operation timed out

If you can merge it in your branch, it would be great.

For information, my pellemetic version is v4.00
