### PR TITLE
Add Pellematic Off/Auto/On Select

### DIFF
--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -602,6 +602,15 @@ PE_SENSOR_TYPES = {
     "L_statetext": ["Pellematic State", "L_statetext", None, "mdi:fire-circle"],
 }
 
+PE_SELECT_TYPES = {
+    "mode": [
+        "Pellematic{0} Mode",
+        "mode",
+        "mode",
+        ["0_off","1_auto","2_force"]
+    ],
+}
+
 SE1_SENSOR_TYPES = {
     "L_flow_temp": [
         "Solar Gain Flow Temperature",

--- a/custom_components/oekofen_pellematic_compact/strings.json
+++ b/custom_components/oekofen_pellematic_compact/strings.json
@@ -16,7 +16,7 @@
           "num_of_hot_water": "Num of hot water circuits (HWx)",
           "num_of_pellematic_heaters": "Num of Pellematic heaters (PELx)",
           "num_of_smart_pv_se_count" : "Num of Smart PV (SEx)",
-          "num_of_smart_pv_sk_count" : "Num of Smart PV (SKx)"     
+          "num_of_smart_pv_sk_count" : "Num of thermal solar collectors (SKx)"     
         }
       }
     },


### PR DESCRIPTION
Sometimes I want to make sure my pellematic does not start up while still having the heat circuit enabled.

The added select allows me to do that. Would be nice to have it added to your integration.

It sets the `mode` value of `pe1-x` (similar to `mode_auto` of `ww` and `hk` entities, but for some reason named differently).

To e.g. set the mode to 0 - Off, it calls `<your-ip>:4321/<your-pw>/pe1_mode=0`:

```
"pe1": {
    "L_temp_act": 285,
    "L_temp_set": 80,
    ...
    "mode": 0
}
```



![image](https://github.com/user-attachments/assets/4f297e8a-c60e-4a95-bd95-dba7ebb79968)

