### PR TITLE
add l_state and SensorStateClass.MEASUREMENT

### DIFF
--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -811,6 +811,12 @@ HK_SENSOR_TYPES = {
         None,
         "mdi:heating-coil",
     ],
+    "L_state": [
+        "Heating Circuit{0} State numeric",
+        "L_state",
+        None,
+        "mdi:heating-coil",
+    ],
     "name": [
         "Heating Circuit{0} Name",
         "name",

--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -503,6 +503,8 @@ class PellematicSensor(SensorEntity):
         if self.unit_of_measurement == UnitOfTime.MILLISECONDS:
             self._attr_device_class = SensorDeviceClass.DURATION
             self._attr_state_class = SensorStateClass.MEASUREMENT
+        if self._key == 'L_state' or self._key == 'mode_auto' or self._key == 'oekomode':
+            self._attr_state_class = SensorStateClass.MEASUREMENT
 
         _LOGGER.debug(
             "Adding a PellematicSensor : %s, %s, %s, %s, %s, %s, %s, %s, %s",


### PR DESCRIPTION
Add l_state (numeric)
And set numeric class (SensorStateClass.MEASUREMENT) for L_state, mode_auto and oekomode

I don't know if this is the best way to add the SensorStateClass.MEASUREMENT class to L_state and others.
Maybe by adding a parameter in their configuration in const.py