### PR TITLE
Support for controlling "heat once" mode and "set down" temperatures

### DIFF
--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -858,6 +858,15 @@ HK_NUMBER_TYPES = {
         40,
         0.5
     ],
+    "temp_setback": [
+        "Heating Circuit{0} Set Down Temp",
+        "temp_setback",
+        NumberDeviceClass.TEMPERATURE,
+        UnitOfTemperature.CELSIUS,
+        10,
+        40,
+        0.5
+    ],
 }
 
 HK_BINARY_SENSOR_TYPES = {

--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -1005,6 +1005,12 @@ WW_SELECT_TYPES = {
         "mode",
         ["0_off","1_auto","2_force"]
     ],
+    "heat_once": [
+        "Hot Water Circuit{0} Heat Once",
+        "heat_once",
+        "heat_once",
+        ["0_off","1_on"]
+    ],
 }
 
 WW_NUMBER_TYPES = {

--- a/custom_components/oekofen_pellematic_compact/strings.json
+++ b/custom_components/oekofen_pellematic_compact/strings.json
@@ -44,6 +44,12 @@
           "1_auto": "1 - Auto",
           "2_force": "2 - Forced"
         }
+      },
+      "heat_once": {
+        "state": {
+          "0_off": "0 - Off",
+          "1_on": "1 - On"
+        }
       }
     },
 	"switch": {


### PR DESCRIPTION
Should address #77 and #80.
Tested both of them on my own setup.

Only issue I still have with this is that the translations are not applied even though I added the texts to `strings.json` and used the same key as in `const.py`.

@dominikamann, Any idea what's missing to make this work?
![image](https://github.com/user-attachments/assets/1ed7cacb-4d86-46d8-b27c-0383fbeea216)


