### PR TITLE
#121 Add support for new JSON format 

### DIFF
--- a/custom_components/oekofen_pellematic_compact/__init__.py
+++ b/custom_components/oekofen_pellematic_compact/__init__.py
@@ -182,8 +182,6 @@ def fetch_data(url: str):
 
     # Hotfix for pellematic update 4.02 (invalid json)
     str_response = str_response.replace("L_statetext:", 'L_statetext":')
-    # Hotfix for changed interface wp_data1 instead of wp1
-    str_response = str_response.replace("wp_data", "wp")
     result = json.loads(str_response, strict=False)
     return result
 

--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -1223,6 +1223,45 @@ WP_SENSOR_TYPES = {
     ]
 }
 
+WP_DATA_SENSOR_TYPES = {
+    "L_jaz_all": [
+        "Heat Pump{0} JAZ",
+        "L_jaz_all",
+        None,
+        "mdi:numeric",
+    ],
+    "L_jaz_heat": [
+        "Heat Pump{0} JAZ Heat",
+        "L_jaz_heat",
+        None,
+        "mdi:numeric",
+    ],
+    "L_jaz_cool": [
+        "Heat Pump{0} JAZ Cool",
+        "L_jaz_cool",
+        None,
+        "mdi:numeric",
+    ],
+    "L_az_all": [
+        "Heat Pump{0} AZ",
+        "L_az_all",
+        None,
+        "mdi:numeric",
+    ],
+    "L_az_heat": [
+        "Heat Pump{0} AZ Heat",
+        "L_az_heat",
+        None,
+        "mdi:numeric",
+    ],
+    "L_az_cool": [
+        "Heat Pump{0} AZ Cool",
+        "L_az_cool",
+        None,
+        "mdi:numeric",
+    ]
+}
+
 WW_SENSOR_TYPES = {
     "L_temp_set": [
         "Hot Water Circuit{0} Temperature set ",

--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -37,6 +37,7 @@ from .const import (
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     WP_SENSOR_TYPES,
+    WP_DATA_SENSOR_TYPES,
     DEFAULT_NUM_OF_HEAT_PUMPS,
     DEFAULT_NUM_OF_HOT_WATER,
     DEFAULT_NUM_OF_PELLEMATIC_HEATER,
@@ -374,6 +375,18 @@ async def async_setup_entry(
                 hub,
                 device_info,
                 f"wp{heatpump_count+1}",
+                name.format(" " + str(heatpump_count + 1)),
+                key,
+                unit,
+                icon,
+            )
+            entities.append(sensor)
+        for name, key, unit, icon in WP_DATA_SENSOR_TYPES.values():
+            sensor = PellematicSensor(
+                hub_name,
+                hub,
+                device_info,
+                f"wp_data{heatpump_count+1}",
                 name.format(" " + str(heatpump_count + 1)),
                 key,
                 unit,


### PR DESCRIPTION
Ökofen put the following properties under "wp_data" instead of "wp" in a new version. So we also need to support it. 

  "wp_data1":{
    "wp_data_info":"heatpump data",
    "L_jaz_all":{"val":3.9542074, "factor":1, "text":"JAZ Betrieb"}, 
    "L_jaz_heat":{"val":3.8466387, "factor":1, "text":"JAZ Heizbetrieb"}, 
    "L_jaz_cool":{"val":0.0, "factor":1, "text":"JAZ Kühlbetrieb"}, 
    "L_az_all":{"val":3.9542074, "factor":1, "text":"Gesamt AZ Betrieb"}, 
    "L_az_heat":{"val":3.8466387, "factor":1, "text":"Gesamt AZ Heizbetrieb"}, 
    "L_az_cool":{"val":0.0, "factor":1, "text":"Gesamt AZ Kühlbetrieb"}
  },