### PR TITLE
Add new sensors for heat pump heating rod parameters

### DIFF
--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -1310,6 +1310,36 @@ WP_SENSOR_TYPES = {
         None,
         "mdi:heat-pump",
     ]
+    "heater_act": [
+        "Heat Pump{0} Heating activation temperature",
+        "heater_act",
+        UnitOfTemperature.CELSIUS,
+        "mdi:heat-pump",
+    ],
+    "L_heater_val": [
+        "Heat Pump{0} Electrical heater power",
+        "L_heater_val",
+        UnitOfPower.WATT,
+        None, 
+    ],
+    "L_heater_temp": [
+        "Heat Pump{0} Electrical heater temperature",
+        "L_heater_temp",
+        UnitOfTemperature.CELSIUS,
+        None, 
+    ],
+    "L_heater_steps": [
+        "Heat Pump{0} Electrical heater stage",
+        "L_heater_steps",
+        PERCENTAGE,
+        None,
+    ],
+    "L_heater_set": [
+        "Heat Pump{0} Electrical heater setpoint",
+        "L_heater_set",
+        PERCENTAGE,
+        None,
+    ]    
 }
 
 WP_DATA_SENSOR_TYPES = {


### PR DESCRIPTION
These sensors were missing according to the last 5 lines from the JSON answer:

```JSON 
"wp1":{
    "wp_info":"heatpump data",
    "L_state":{"val":64, "factor":1, "text":"Status"}, 
    "L_statetext":"Heizungsanforderung",
    "L_sg_ready":{"val":2, "format":"0:-|1:SG Ready 1|2:SG Ready 2|3:SG Ready 3|4:SG Ready 4", "text":"SG Ready"}, 
    "set_sg_ready":{"val":0, "format":"0:-|1:SG Ready 1|2:SG Ready 2|3:SG Ready 3|4:SG Ready 4", "text":"SG Ready"}, 
    "L_cop":{"val":3.4869063, "factor":1, "text":"COP"}, 
    "L_uwp":{"val":0.3, "factor":1, "text":"Umwaelzpumpe"}, 
    "L_fan":{"val":0.33600003, "unit":"%", "factor":100, "text":"Lüfter"}, 
    "L_highpressure":{"val":14.625, "unit":"Bar", "factor":1, "text":"Hochdruck"}, 
    "L_lowpressure":{"val":3.4745426, "unit":"Bar", "factor":1, "text":"Niederdruck"}, 
    "L_overheat_is":{"val":9.749996, "unit":"K", "factor":0.1, "text":"Überhitzung"}, 
    "L_overheat_set":{"val":10.1465645, "unit":"K", "factor":0.1, "text":"Überhitzung"}, 
    "L_eev":{"val":110.0, "factor":1, "text":"EEV Heizen"}, 
    "L_compressor_act":{"val":0.17, "unit":"%", "factor":67, "text":"Kompressor"}, 
    "L_overheat":{"val":110.0, "factor":1, "text":"EEV Kühlen"}, 
    "L_compressor_in":{"val":8.2, "unit":"°C", "factor":1, "text":"Kompressor Eingang"}, 
    "L_compressor_out":{"val":79.4, "unit":"°C", "factor":1, "text":"Kompressor Ausgang"}, 
    "L_temp_src_in":{"val":3.9, "unit":"°C", "factor":1, "text":"Lüfter Eingang"}, 
    "L_temp_src_out":{"val":0.6, "unit":"°C", "factor":1, "text":"Lüfter Ausgang"}, 
    "L_temp_flow_is":{"val":47.3, "unit":"°C", "factor":1, "text":"Vorlauf"}, 
    "L_temp_flow_set":{"val":47.6, "unit":"°C", "factor":1, "text":"Vorlauf"}, 
    "L_temp_return_is":{"val":41.9, "unit":"°C", "factor":1, "text":"Rücklauf"}, 
    "L_flowrate":{"val":0.13285919, "unit":"l/min", "factor":60, "text":"Durchfluss"}, 
    "L_temp_vap":{"val":-1.5868387, "unit":"°C", "factor":1, "text":"Verdampfungstemperatur"}, 
    "L_temp_condens":{"val":45.936176, "unit":"°C", "factor":1, "text":"Kondensationstemperatur"}, 
    "L_temp_heater":{"val":3006.0708, "unit":"W", "factor":1, "text":"Heizleistung"}, 
    "L_temp_cooler":{"val":0.0, "unit":"W", "factor":1, "text":"Kühlleistung"}, 
    "L_el_energy":{"val":860.0564, "unit":"W", "factor":1, "text":"Elektrische Leistung"}, 
    "L_total_runtime":{"val":3574627, "unit":"h", "factor":2.777777777777778E-4, "text":"Betriebsstunden"}, 
    "L_min_runtime":{"val":379, "unit":"h", "factor":2.777777777777778E-4, "text":"Min. Laufzeit"}, 
    "L_max_runtime":{"val":27744, "unit":"h", "factor":2.777777777777778E-4, "text":"Max. Laufzeit"}, 
    "L_activation_count":{"val":634, "factor":1, "text":"Kompressorstarts"}, 
    "mode":{"val":1, "format":"0:Aus|1:Auto|2:Ein", "text":"Betriebsart"}, 
    "ambient_mode":{"val":0, "format":"0:Aus|1:Ein", "text":"Außentemperatur Modus"}, 
    "night_mode":{"val":0, "format":"0:Aus|1:Ein", "text":"NachtModus"}, 
    "heater":{"val":0, "format":"0:Aus|1:Heizung|2:Warmwasser|3:Auto", "text":"Heizstab Einstellungen"}, 
    "heater_act":{"val":-30, "unit":"°C", "factor":0.1, "min":-150, "max":150, "text":"Heizstab aktivieren"}, 
    "L_heater_steps":{"val":0, "unit":"%", "factor":1, "min":-32768, "max":32767, "text":"Regelstufe"}, 
    "L_heater_set":{"val":0, "unit":"%", "factor":1, "min":0, "max":100, "text":"Heizstab"}, 
    "L_heater_val":{"val":0, "unit":"W", "factor":1, "min":-32768, "max":32767, "text":"Heizstab"}, 
    "L_heater_temp":{"val":462, "unit":"°C", "factor":0.1, "min":-32768, "max":32767, "text":"Heizstab Temperatur"}
  },
```