### PR TITLE
Replace None with COP and JAZ in related heat pump sensor definitions

### DIFF
--- a/custom_components/oekofen_pellematic_compact/const.py
+++ b/custom_components/oekofen_pellematic_compact/const.py
@@ -1067,7 +1067,7 @@ WP_SENSOR_TYPES = {
     "L_cop": [
         "Heat Pump{0} COP",
         "L_cop",
-        None,
+        "COP",
         "mdi:heat-pump",
     ],
     "L_uwp": [
@@ -1223,37 +1223,37 @@ WP_SENSOR_TYPES = {
     "L_jaz_all": [
         "Heat Pump{0} JAZ",
         "L_jaz_all",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_jaz_heat": [
         "Heat Pump{0} JAZ Heat",
         "L_jaz_heat",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_jaz_cool": [
         "Heat Pump{0} JAZ Cool",
         "L_jaz_cool",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_az_all": [
         "Heat Pump{0} AZ",
         "L_az_all",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_az_heat": [
         "Heat Pump{0} AZ Heat",
         "L_az_heat",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_az_cool": [
         "Heat Pump{0} AZ Cool",
         "L_az_cool",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "mode": [
@@ -1340,37 +1340,37 @@ WP_DATA_SENSOR_TYPES = {
     "L_jaz_all": [
         "Heat Pump Data{0} JAZ",
         "L_jaz_all",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_jaz_heat": [
         "Heat Pump Data{0} JAZ Heat",
         "L_jaz_heat",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_jaz_cool": [
         "Heat Pump Data{0} JAZ Cool",
         "L_jaz_cool",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_az_all": [
         "Heat Pump Data{0} AZ",
         "L_az_all",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_az_heat": [
         "Heat Pump Data{0} AZ Heat",
         "L_az_heat",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
     "L_az_cool": [
         "Heat Pump Data{0} AZ Cool",
         "L_az_cool",
-        None,
+        "JAZ",
         "mdi:numeric",
     ],
 }


### PR DESCRIPTION
This workaround forces HA to interpret the COP, AZ and JAZ sensors as history values which allows to use them in diagrams.

Fixes #137 