### PR TITLE
Filter sentinel / overflow readings from ÖkoFEN API to prevent sensor spikes (INT16 max/min) + fix coroutine state regression

### DIFF
--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -76,7 +76,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 _LOGGER = logging.getLogger(__name__)
 
-async def _sanitize_oekofen_value(raw_data: dict, value: Any) -> Any:
+def _sanitize_oekofen_value(raw_data: dict, value: Any) -> Any:
     # Drop clearly invalid/sentinel values coming from the Ökofen JSON API
     if value is None:
         return None


### PR DESCRIPTION
## Summary

This PR adds defensive handling for invalid/sentinel readings occasionally returned by the ÖkoFEN JSON API (e.g., values close to **32767** / **-32768**). These transient values currently propagate into Home Assistant sensor states and can corrupt statistics and the Energy Dashboard (massive spikes/deltas).

---

## Problem

In real-world installations, some API fields sporadically return extreme values consistent with 16‑bit integer boundaries (e.g., **32765**, **32767**, **-32768**) for a single poll and then return to normal. When such a value is used directly (or converted in templates), it can create absurd consumption spikes (example: `32765 × 4.8 kWh/kg = 157,272 kWh`).

---

## Changes

1. **Add sanitize helper**
   Introduce `_sanitize_oekofen_value(raw_data, value)`:

* Converts common invalid HA states (`unknown`, `unavailable`, empty) to `None`
* Attempts to parse numeric strings where applicable
* Drops clearly invalid **sentinel/overflow** values:

  * If `raw_data` provides `min`/`max`, reject values near boundaries (e.g., `>= max - 2` or `<= min + 2`)
  * This reliably catches spikes like 32765/32767/-32768 without requiring per-sensor hardcoding

2. **Apply sanitizer before publishing state**
   Apply `_sanitize_oekofen_value(...)` in the relevant sensor value calculation/update paths (e.g., in both `state`/`native_value` and `_update_state`, depending on the entity implementation).

3. **Return `None` for invalid values**
   Invalid readings are mapped to `None`, making the entity `unknown/unavailable` instead of publishing a numeric spike. This protects HA statistics and Energy Dashboard deltas.

4. **Fix coroutine-state regression**
   Ensure the sanitizer is a normal synchronous function (`def`, not `async def`) since it is invoked from synchronous code paths.

---

## Why this approach

* **Generic**: Works across multiple sensors/fields, not just one specific “today” counter.
* **Uses metadata**: Relies on the API’s own `min`/`max` bounds when available.
* **Non-invasive**: Does not change normal values; only filters extreme boundary placeholders.
* **HA-friendly**: Returning `None` avoids corrupting long-term statistics.

---

## Notes / Compatibility

* This is a defensive fix for transient invalid API responses. It should not affect legitimate readings.
* If any sensor field is legitimately expected to hit the boundary values defined by `min`/`max`, the “near-boundary” threshold can be adjusted. The current `±2` approach is intentionally conservative and targets overflow/sentinel patterns.

---

Closes: https://github.com/dominikamann/oekofen-pellematic-compact/issues/147
