### PR TITLE
Add Home Assistant entity translations for dynamic entities

### DIFF
--- a/custom_components/oekofen_pellematic_compact/dynamic_discovery.py
+++ b/custom_components/oekofen_pellematic_compact/dynamic_discovery.py
@@ -104,6 +104,15 @@ def get_translation_key(component: str, key: str) -> Optional[str]:
     base_component = "".join(c for c in component if not c.isdigit())
     return ENTITY_TRANSLATION_KEYS.get((base_component, key.replace("#2", "")))
 
+def get_translation_placeholders(component: str, index: int) -> dict[str, str] | None:
+    """Return translation placeholders for numbered Ökofen components."""
+    base_component = "".join(c for c in component if not c.isdigit())
+
+    if base_component in ("ww", "sk") and index > 0:
+        return {"index": str(index)}
+
+    return None
+
 # Keys to ignore (metadata/info fields)
 IGNORE_KEYS = {
     "system_info",
@@ -523,6 +532,7 @@ def create_sensor_definition(
         "key": key,
         "name": name,
         "translation_key": get_translation_key(component, key),
+        "translation_placeholders": get_translation_placeholders(component, index),
         "unique_id": f"{component}_{key}",
         "unit": normalize_unit(data.get("unit")),
         "device_class": infer_device_class(data, key),

--- a/custom_components/oekofen_pellematic_compact/dynamic_discovery.py
+++ b/custom_components/oekofen_pellematic_compact/dynamic_discovery.py
@@ -38,6 +38,72 @@ COMPONENT_NAMES = {
     "thirdparty": "Third Party Sensor",
 }
 
+
+# Home Assistant translation keys for known Ökofen API entities.
+#
+# Only known keys get a translation key. Unknown/new firmware keys keep using
+# the API-provided text (or the raw API key) as a fallback, preserving dynamic
+# discovery and forward compatibility.
+ENTITY_TRANSLATION_KEYS = {
+    # System
+    ("system", "L_ambient"): "system_ambient_temperature",
+    ("system", "L_errors"): "system_errors",
+    ("system", "L_usb_stick"): "system_usb_stick",
+    ("system", "L_boiler_temp"): "system_boiler_temperature",
+    ("system", "L_existing_boiler"): "system_existing_boiler",
+    ("system", "mode"): "system_mode",
+
+    # Weather
+    ("weather", "L_temp"): "weather_outside_temperature",
+    ("weather", "L_clouds"): "weather_cloudiness",
+    ("weather", "L_forecast_temp"): "weather_forecast_temperature",
+    ("weather", "L_forecast_clouds"): "weather_forecast_cloudiness",
+    ("weather", "L_forecast_today"): "weather_forecast_today",
+    ("weather", "L_starttime"): "weather_start_time",
+    ("weather", "L_endtime"): "weather_end_time",
+    ("weather", "L_source"): "weather_source",
+    ("weather", "L_location"): "weather_location",
+    ("weather", "cloud_limit"): "weather_cloud_limit",
+    ("weather", "hysteresys"): "weather_hysteresis",
+    ("weather", "offtemp"): "weather_off_temperature",
+    ("weather", "lead"): "weather_lead_time",
+    ("weather", "refresh"): "weather_refresh",
+    ("weather", "oekomode"): "weather_eco_mode",
+
+    # Domestic hot water
+    ("ww", "L_temp_set"): "hot_water_target_temperature",
+    ("ww", "L_ontemp_act"): "hot_water_on_temperature",
+    ("ww", "L_offtemp_act"): "hot_water_off_temperature",
+    ("ww", "L_pump"): "hot_water_pump",
+    ("ww", "L_state"): "hot_water_state",
+    ("ww", "L_statetext"): "hot_water_status",
+    ("ww", "time_prg"): "hot_water_time_program",
+    ("ww", "sensor_on"): "hot_water_sensor_on",
+    ("ww", "sensor_off"): "hot_water_sensor_off",
+    ("ww", "mode_auto"): "hot_water_mode",
+    ("ww", "heat_once"): "hot_water_heat_once",
+    ("ww", "temp_min_set"): "hot_water_min_temperature",
+    ("ww", "temp_max_set"): "hot_water_max_temperature",
+    ("ww", "smartstart"): "hot_water_smart_start",
+    ("ww", "use_boiler_heat"): "hot_water_use_boiler_heat",
+    ("ww", "oekomode"): "hot_water_eco_mode",
+
+    # Solar
+    ("sk", "L_koll_temp"): "solar_collector_temperature",
+    ("sk", "L_spu"): "solar_storage_temperature",
+    ("sk", "L_pump"): "solar_pump",
+    ("sk", "L_state"): "solar_state",
+    ("sk", "L_statetext"): "solar_status",
+    ("sk", "mode"): "solar_mode",
+    ("sk", "cooling"): "solar_cooling",
+    ("sk", "spu_max"): "solar_storage_max_temperature",
+}
+
+def get_translation_key(component: str, key: str) -> Optional[str]:
+    """Return a Home Assistant translation key for a known Ökofen entity."""
+    base_component = "".join(c for c in component if not c.isdigit())
+    return ENTITY_TRANSLATION_KEYS.get((base_component, key.replace("#2", "")))
+
 # Keys to ignore (metadata/info fields)
 IGNORE_KEYS = {
     "system_info",
@@ -456,6 +522,7 @@ def create_sensor_definition(
         "component": component,
         "key": key,
         "name": name,
+        "translation_key": get_translation_key(component, key),
         "unique_id": f"{component}_{key}",
         "unit": normalize_unit(data.get("unit")),
         "device_class": infer_device_class(data, key),

--- a/custom_components/oekofen_pellematic_compact/number.py
+++ b/custom_components/oekofen_pellematic_compact/number.py
@@ -90,7 +90,13 @@ class PellematicNumber(NumberEntity):
         self._hub = hub
         self._prefix = number_definition['component']
         self._key = number_definition['key']
-        self._name = f"{self._platform_name} {number_definition['name']}"
+        translation_key = number_definition.get("translation_key")
+        
+        if translation_key:
+            self._attr_has_entity_name = True
+            self._attr_translation_key = translation_key
+        else:
+            self._name = f"{self._platform_name} {number_definition['name']}"
         self._attr_unique_id = f"{self._platform_name.lower()}_{self._prefix}_{self._key}"
         # Use component_key for entity_id instead of long human-readable name
         self._attr_object_id = f"{self._prefix}_{self._key}".lower()
@@ -115,7 +121,11 @@ class PellematicNumber(NumberEntity):
         
         _LOGGER.debug(
             "Adding dynamic PellematicNumber: %s, %s, min=%s, max=%s, step=%s, factor=%s",
-            self._name,
+           getattr(
+                self,
+                "_name",
+                getattr(self, "_attr_translation_key", None),
+),
             self._attr_unique_id,
             self._attr_native_min_value,
             self._attr_native_max_value,
@@ -207,11 +217,6 @@ class PellematicNumber(NumberEntity):
     def _update_state(self):
         self._attr_native_value = self._update_native_value()
         
-    @property
-    def name(self):
-        """Return the name."""
-        return f"{self._name}"
-
     @property
     def state(self) -> float | None:
         """Return the entity state."""

--- a/custom_components/oekofen_pellematic_compact/number.py
+++ b/custom_components/oekofen_pellematic_compact/number.py
@@ -95,6 +95,9 @@ class PellematicNumber(NumberEntity):
         if translation_key:
             self._attr_has_entity_name = True
             self._attr_translation_key = translation_key
+            translation_placeholders = number_definition.get("translation_placeholders")
+            if translation_placeholders:
+                self._attr_translation_placeholders = translation_placeholders
         else:
             self._name = f"{self._platform_name} {number_definition['name']}"
         self._attr_unique_id = f"{self._platform_name.lower()}_{self._prefix}_{self._key}"

--- a/custom_components/oekofen_pellematic_compact/select.py
+++ b/custom_components/oekofen_pellematic_compact/select.py
@@ -92,18 +92,30 @@ class PellematicSelect(SelectEntity):
         self._hub = hub
         self._prefix = select_definition['component']
         self._key = select_definition['key']
-        self._name = f"{self._platform_name} {select_definition['name']}"
+        translation_key = select_definition.get("translation_key")
+
+        if translation_key:
+            self._attr_has_entity_name = True
+            self._attr_translation_key = translation_key
+        else:
+            self._name = f"{self._platform_name} {select_definition['name']}"
+            
         self._attr_unique_id = f"{self._platform_name.lower()}_{self._prefix}_{self._key}"
         # Use component_key for entity_id instead of long human-readable name
         self._attr_object_id = f"{self._prefix}_{self._key}".lower()
         self._attr_current_option = None
         self._attr_options = select_definition['options']
         self._device_info = device_info
-        self._attr_translation_key = None
+        
         
         _LOGGER.debug(
             "Adding dynamic PellematicSelect: %s, %s, options: %s",
-            self._name,
+            getattr(
+                self,
+                "_name",
+                getattr(self, "_attr_translation_key", None),
+            ),
+            
             self._attr_unique_id,
             self._attr_options,
         )
@@ -173,11 +185,6 @@ class PellematicSelect(SelectEntity):
     def _update_state(self):
         self._attr_current_option = self._update_current_option()
         
-    @property
-    def name(self):
-        """Return the name."""
-        return f"{self._name}"
-
     @property
     def state(self):
         """Return the entity state."""

--- a/custom_components/oekofen_pellematic_compact/select.py
+++ b/custom_components/oekofen_pellematic_compact/select.py
@@ -97,6 +97,10 @@ class PellematicSelect(SelectEntity):
         if translation_key:
             self._attr_has_entity_name = True
             self._attr_translation_key = translation_key
+            
+            translation_placeholders = select_definition.get("translation_placeholders")
+            if translation_placeholders:
+                self._attr_translation_placeholders = translation_placeholders
         else:
             self._name = f"{self._platform_name} {select_definition['name']}"
             

--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -202,7 +202,12 @@ class PellematicBinarySensor(BinarySensorEntity):
 
         _LOGGER.debug(
             "Adding dynamic PellematicBinarySensor: %s, %s",
-            getattr(self, "_name", self._attr_translation_key)
+            getattr(
+                self,
+                "_name",
+                getattr(self, "_attr_translation_key", None),
+            ),
+            self._attr_unique_id,
         )
 
     @property
@@ -227,13 +232,6 @@ class PellematicBinarySensor(BinarySensorEntity):
     @callback
     def _api_data_updated(self):
         self.async_write_ha_state()
-
-    @property
-    def name(self):
-        """Return the fallback name for untranslated entities."""
-        if hasattr(self, "_name"):
-            return self._name
-        return None
 
     @property
     def icon(self):
@@ -325,10 +323,17 @@ class PellematicSensor(SensorEntity):
             'l_az_cool', 'l_cop',
         ):
             self._attr_state_class = SensorStateClass.MEASUREMENT
-        
+            
         _LOGGER.debug(
             "Adding dynamic PellematicSensor: %s, %s, %s, %s",
-            self._name, self._attr_unique_id, self._unit_of_measurement, self._icon,
+            getattr(
+                self,
+                "_name",
+                getattr(self, "_attr_translation_key", None),
+            ),
+            self._attr_unique_id,
+            self._unit_of_measurement,
+            self._icon,
         )
 
     async def async_added_to_hass(self):
@@ -398,12 +403,6 @@ class PellematicSensor(SensorEntity):
     def _update_state(self):
         self._state = self._compute_state()
 
-    @property
-    def name(self):
-        """Return the fallback name for untranslated entities."""
-        if hasattr(self, "_name"):
-            return self._name
-        return None
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -179,7 +179,7 @@ class PellematicBinarySensor(BinarySensorEntity):
         self._hub = hub
         self._prefix = sensor_definition['component']
         self._key = sensor_definition['key']
-        self._name = f"{self._platform_name} {sensor_definition['name']}"
+        translation_key = sensor_definition.get("translation_key")  if translation_key:     self._attr_has_entity_name = True     self._attr_translation_key = translation_key else:     # Fallback for unknown Ökofen API keys     self._name = f"{self._platform_name} {sensor_definition['name']}"
         self._attr_unique_id = (
             f"{self._platform_name.lower()}_{self._prefix}_{self._key}"
         )
@@ -259,7 +259,16 @@ class PellematicSensor(SensorEntity):
         self._hub = hub
         self._prefix = sensor_definition['component']
         self._key = sensor_definition['key']
-        self._name = f"{self._platform_name} {sensor_definition['name']}"
+        translation_key = sensor_definition.get("translation_key")
+
+        if translation_key:
+            self._attr_has_entity_name = True
+            self._attr_translation_key = translation_key
+        else:
+            # Fallback for unknown Ökofen API keys
+            self._name = f"{self._platform_name} {sensor_definition['name']}"
+        
+     
         self._attr_unique_id = (
             f"{self._platform_name.lower()}_{self._prefix}_{self._key}"
         )
@@ -381,8 +390,10 @@ class PellematicSensor(SensorEntity):
 
     @property
     def name(self):
-        """Return the name."""
-        return f"{self._name}"
+        """Return the fallback name for untranslated entities."""
+        if hasattr(self, "_name"):
+            return self._name
+        return None
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -184,6 +184,9 @@ class PellematicBinarySensor(BinarySensorEntity):
         if translation_key:     
             self._attr_has_entity_name = True     
             self._attr_translation_key = translation_key 
+            translation_placeholders = sensor_definition.get("translation_placeholders")
+            if translation_placeholders:
+                self._attr_translation_placeholders = translation_placeholders
         else:     
             # Fallback for unknown Ökofen API keys     
             self._name = f"{self._platform_name} {sensor_definition['name']}"
@@ -272,6 +275,9 @@ class PellematicSensor(SensorEntity):
         if translation_key:
             self._attr_has_entity_name = True
             self._attr_translation_key = translation_key
+            translation_placeholders = sensor_definition.get("translation_placeholders")
+            if translation_placeholders:
+                self._attr_translation_placeholders = translation_placeholders
         else:
             # Fallback for unknown Ökofen API keys
             self._name = f"{self._platform_name} {sensor_definition['name']}"

--- a/custom_components/oekofen_pellematic_compact/sensor.py
+++ b/custom_components/oekofen_pellematic_compact/sensor.py
@@ -179,7 +179,15 @@ class PellematicBinarySensor(BinarySensorEntity):
         self._hub = hub
         self._prefix = sensor_definition['component']
         self._key = sensor_definition['key']
-        translation_key = sensor_definition.get("translation_key")  if translation_key:     self._attr_has_entity_name = True     self._attr_translation_key = translation_key else:     # Fallback for unknown Ökofen API keys     self._name = f"{self._platform_name} {sensor_definition['name']}"
+        
+        translation_key = sensor_definition.get("translation_key")  
+        if translation_key:     
+            self._attr_has_entity_name = True     
+            self._attr_translation_key = translation_key 
+        else:     
+            # Fallback for unknown Ökofen API keys     
+            self._name = f"{self._platform_name} {sensor_definition['name']}"
+            
         self._attr_unique_id = (
             f"{self._platform_name.lower()}_{self._prefix}_{self._key}"
         )
@@ -194,7 +202,7 @@ class PellematicBinarySensor(BinarySensorEntity):
 
         _LOGGER.debug(
             "Adding dynamic PellematicBinarySensor: %s, %s",
-            self._name, self._attr_unique_id,
+            getattr(self, "_name", self._attr_translation_key)
         )
 
     @property
@@ -222,8 +230,10 @@ class PellematicBinarySensor(BinarySensorEntity):
 
     @property
     def name(self):
-        """Return the name."""
-        return f"{self._name}"
+        """Return the fallback name for untranslated entities."""
+        if hasattr(self, "_name"):
+            return self._name
+        return None
 
     @property
     def icon(self):

--- a/custom_components/oekofen_pellematic_compact/strings.json
+++ b/custom_components/oekofen_pellematic_compact/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to your \u00d6kofen Pellematic",
+        "title": "Connect to your Ökofen Pellematic",
         "description": "Enter the JSON API URL (e.g., {example_url}). The system will automatically discover your configuration.\n\n{charset_warning}",
         "data": {
           "host": "JSON API URL (including password)",
@@ -33,13 +33,184 @@
     }
   },
   "entity": {
-	"select": {
+    "sensor": {
+      "system_ambient_temperature": {
+        "name": "Ambient temperature"
+      },
+      "system_errors": {
+        "name": "Errors"
+      },
+      "system_usb_stick": {
+        "name": "USB stick"
+      },
+      "system_boiler_temperature": {
+        "name": "Boiler temperature"
+      },
+      "system_existing_boiler": {
+        "name": "Existing boiler"
+      },
+      "system_mode": {
+        "name": "System mode"
+      },
+      "weather_outside_temperature": {
+        "name": "Outside temperature"
+      },
+      "weather_cloudiness": {
+        "name": "Cloudiness"
+      },
+      "weather_forecast_temperature": {
+        "name": "Forecast temperature"
+      },
+      "weather_forecast_cloudiness": {
+        "name": "Forecast cloudiness"
+      },
+      "weather_forecast_today": {
+        "name": "Today's forecast"
+      },
+      "weather_start_time": {
+        "name": "Start time"
+      },
+      "weather_end_time": {
+        "name": "End time"
+      },
+      "weather_source": {
+        "name": "Weather source"
+      },
+      "weather_location": {
+        "name": "Weather location"
+      },
+      "weather_cloud_limit": {
+        "name": "Cloud limit"
+      },
+      "weather_hysteresis": {
+        "name": "Hysteresis"
+      },
+      "weather_off_temperature": {
+        "name": "Off temperature"
+      },
+      "weather_lead_time": {
+        "name": "Lead time"
+      },
+      "weather_refresh": {
+        "name": "Refresh"
+      },
+      "weather_eco_mode": {
+        "name": "Eco mode"
+      },
+      "hot_water_target_temperature": {
+        "name": "Hot water {index} target temperature"
+      },
+      "hot_water_on_temperature": {
+        "name": "Hot water {index} on temperature"
+      },
+      "hot_water_off_temperature": {
+        "name": "Hot water {index} off temperature"
+      },
+      "hot_water_pump": {
+        "name": "Hot water {index} pump"
+      },
+      "hot_water_state": {
+        "name": "Hot water {index} state"
+      },
+      "hot_water_status": {
+        "name": "Hot water {index} status"
+      },
+      "hot_water_time_program": {
+        "name": "Hot water {index} time program"
+      },
+      "hot_water_sensor_on": {
+        "name": "Hot water {index} on sensor"
+      },
+      "hot_water_sensor_off": {
+        "name": "Hot water {index} off sensor"
+      },
+      "hot_water_mode": {
+        "name": "Hot water {index} mode"
+      },
+      "hot_water_heat_once": {
+        "name": "Hot water {index} heat once"
+      },
+      "hot_water_min_temperature": {
+        "name": "Hot water {index} minimum temperature"
+      },
+      "hot_water_max_temperature": {
+        "name": "Hot water {index} maximum temperature"
+      },
+      "hot_water_smart_start": {
+        "name": "Hot water {index} smart start"
+      },
+      "hot_water_use_boiler_heat": {
+        "name": "Hot water {index} use boiler heat"
+      },
+      "hot_water_eco_mode": {
+        "name": "Hot water {index} eco mode"
+      },
+      "solar_collector_temperature": {
+        "name": "Solar {index} collector temperature"
+      },
+      "solar_storage_temperature": {
+        "name": "Solar {index} storage temperature"
+      },
+      "solar_pump": {
+        "name": "Solar {index} pump"
+      },
+      "solar_state": {
+        "name": "Solar {index} state"
+      },
+      "solar_status": {
+        "name": "Solar {index} status"
+      },
+      "solar_mode": {
+        "name": "Solar {index} mode"
+      },
+      "solar_cooling": {
+        "name": "Solar {index} cooling"
+      },
+      "solar_storage_max_temperature": {
+        "name": "Solar {index} maximum storage temperature"
+      }
+    },
+    "binary_sensor": {
+      "hot_water_pump": {
+        "name": "Hot water {index} pump"
+      },
+      "solar_pump": {
+        "name": "Solar {index} pump"
+      }
+    },
+    "number": {
+      "weather_cloud_limit": {
+        "name": "Cloud limit"
+      },
+      "weather_hysteresis": {
+        "name": "Hysteresis"
+      },
+      "weather_off_temperature": {
+        "name": "Off temperature"
+      },
+      "weather_lead_time": {
+        "name": "Lead time"
+      },
+      "hot_water_target_temperature": {
+        "name": "Hot water {index} target temperature"
+      },
+      "hot_water_min_temperature": {
+        "name": "Hot water {index} minimum temperature"
+      },
+      "hot_water_max_temperature": {
+        "name": "Hot water {index} maximum temperature"
+      },
+      "solar_storage_max_temperature": {
+        "name": "Solar {index} maximum storage temperature"
+      }
+    },
+    "select": {
       "heater": {
         "state": {
           "0_off": "0 - Stop",
           "1_auto": "1 - Auto",
           "2_comfort": "2 - Comfort",
-		  "3_slow": "3 - Reduced"
+          "3_slow": "3 - Reduced"
         }
       },
       "mode": {
@@ -55,9 +226,30 @@
           "0_off": "0 - Off",
           "1_on": "1 - On"
         }
+      },
+      "hot_water_mode": {
+        "name": "Hot water {index} mode"
+      },
+      "hot_water_heat_once": {
+        "name": "Hot water {index} heat once"
+      },
+      "hot_water_sensor_on": {
+        "name": "Hot water {index} on sensor"
+      },
+      "hot_water_sensor_off": {
+        "name": "Hot water {index} off sensor"
+      },
+      "hot_water_eco_mode": {
+        "name": "Hot water {index} eco mode"
+      },
+      "solar_mode": {
+        "name": "Solar {index} mode"
+      },
+      "solar_cooling": {
+        "name": "Solar {index} cooling"
       }
     },
-	"switch": {
+    "switch": {
       "onoff": {
         "state": {
           "0_off": "0 - Off",

--- a/custom_components/oekofen_pellematic_compact/translations/en.json
+++ b/custom_components/oekofen_pellematic_compact/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to your \u00d6kofen Pellematic",
+        "title": "Connect to your Ökofen Pellematic",
         "description": "Enter the JSON API URL (e.g., {example_url}). The system will automatically discover your configuration.\n\n{charset_warning}",
         "data": {
           "host": "JSON API URL (including password)",
@@ -33,13 +33,184 @@
     }
   },
   "entity": {
-	"select": {
+    "sensor": {
+      "system_ambient_temperature": {
+        "name": "Ambient temperature"
+      },
+      "system_errors": {
+        "name": "Errors"
+      },
+      "system_usb_stick": {
+        "name": "USB stick"
+      },
+      "system_boiler_temperature": {
+        "name": "Boiler temperature"
+      },
+      "system_existing_boiler": {
+        "name": "Existing boiler"
+      },
+      "system_mode": {
+        "name": "System mode"
+      },
+      "weather_outside_temperature": {
+        "name": "Outside temperature"
+      },
+      "weather_cloudiness": {
+        "name": "Cloudiness"
+      },
+      "weather_forecast_temperature": {
+        "name": "Forecast temperature"
+      },
+      "weather_forecast_cloudiness": {
+        "name": "Forecast cloudiness"
+      },
+      "weather_forecast_today": {
+        "name": "Today's forecast"
+      },
+      "weather_start_time": {
+        "name": "Start time"
+      },
+      "weather_end_time": {
+        "name": "End time"
+      },
+      "weather_source": {
+        "name": "Weather source"
+      },
+      "weather_location": {
+        "name": "Weather location"
+      },
+      "weather_cloud_limit": {
+        "name": "Cloud limit"
+      },
+      "weather_hysteresis": {
+        "name": "Hysteresis"
+      },
+      "weather_off_temperature": {
+        "name": "Off temperature"
+      },
+      "weather_lead_time": {
+        "name": "Lead time"
+      },
+      "weather_refresh": {
+        "name": "Refresh"
+      },
+      "weather_eco_mode": {
+        "name": "Eco mode"
+      },
+      "hot_water_target_temperature": {
+        "name": "Hot water {index} target temperature"
+      },
+      "hot_water_on_temperature": {
+        "name": "Hot water {index} on temperature"
+      },
+      "hot_water_off_temperature": {
+        "name": "Hot water {index} off temperature"
+      },
+      "hot_water_pump": {
+        "name": "Hot water {index} pump"
+      },
+      "hot_water_state": {
+        "name": "Hot water {index} state"
+      },
+      "hot_water_status": {
+        "name": "Hot water {index} status"
+      },
+      "hot_water_time_program": {
+        "name": "Hot water {index} time program"
+      },
+      "hot_water_sensor_on": {
+        "name": "Hot water {index} on sensor"
+      },
+      "hot_water_sensor_off": {
+        "name": "Hot water {index} off sensor"
+      },
+      "hot_water_mode": {
+        "name": "Hot water {index} mode"
+      },
+      "hot_water_heat_once": {
+        "name": "Hot water {index} heat once"
+      },
+      "hot_water_min_temperature": {
+        "name": "Hot water {index} minimum temperature"
+      },
+      "hot_water_max_temperature": {
+        "name": "Hot water {index} maximum temperature"
+      },
+      "hot_water_smart_start": {
+        "name": "Hot water {index} smart start"
+      },
+      "hot_water_use_boiler_heat": {
+        "name": "Hot water {index} use boiler heat"
+      },
+      "hot_water_eco_mode": {
+        "name": "Hot water {index} eco mode"
+      },
+      "solar_collector_temperature": {
+        "name": "Solar {index} collector temperature"
+      },
+      "solar_storage_temperature": {
+        "name": "Solar {index} storage temperature"
+      },
+      "solar_pump": {
+        "name": "Solar {index} pump"
+      },
+      "solar_state": {
+        "name": "Solar {index} state"
+      },
+      "solar_status": {
+        "name": "Solar {index} status"
+      },
+      "solar_mode": {
+        "name": "Solar {index} mode"
+      },
+      "solar_cooling": {
+        "name": "Solar {index} cooling"
+      },
+      "solar_storage_max_temperature": {
+        "name": "Solar {index} maximum storage temperature"
+      }
+    },
+    "binary_sensor": {
+      "hot_water_pump": {
+        "name": "Hot water {index} pump"
+      },
+      "solar_pump": {
+        "name": "Solar {index} pump"
+      }
+    },
+    "number": {
+      "weather_cloud_limit": {
+        "name": "Cloud limit"
+      },
+      "weather_hysteresis": {
+        "name": "Hysteresis"
+      },
+      "weather_off_temperature": {
+        "name": "Off temperature"
+      },
+      "weather_lead_time": {
+        "name": "Lead time"
+      },
+      "hot_water_target_temperature": {
+        "name": "Hot water {index} target temperature"
+      },
+      "hot_water_min_temperature": {
+        "name": "Hot water {index} minimum temperature"
+      },
+      "hot_water_max_temperature": {
+        "name": "Hot water {index} maximum temperature"
+      },
+      "solar_storage_max_temperature": {
+        "name": "Solar {index} maximum storage temperature"
+      }
+    },
+    "select": {
       "heater": {
         "state": {
           "0_off": "0 - Stop",
           "1_auto": "1 - Auto",
           "2_comfort": "2 - Comfort",
-		  "3_slow": "3 - Reduced"
+          "3_slow": "3 - Reduced"
         }
       },
       "mode": {
@@ -55,9 +226,30 @@
           "0_off": "0 - Off",
           "1_on": "1 - On"
         }
+      },
+      "hot_water_mode": {
+        "name": "Hot water {index} mode"
+      },
+      "hot_water_heat_once": {
+        "name": "Hot water {index} heat once"
+      },
+      "hot_water_sensor_on": {
+        "name": "Hot water {index} on sensor"
+      },
+      "hot_water_sensor_off": {
+        "name": "Hot water {index} off sensor"
+      },
+      "hot_water_eco_mode": {
+        "name": "Hot water {index} eco mode"
+      },
+      "solar_mode": {
+        "name": "Solar {index} mode"
+      },
+      "solar_cooling": {
+        "name": "Solar {index} cooling"
       }
     },
-	"switch": {
+    "switch": {
       "onoff": {
         "state": {
           "0_off": "0 - Off",

--- a/custom_components/oekofen_pellematic_compact/translations/fr.json
+++ b/custom_components/oekofen_pellematic_compact/translations/fr.json
@@ -2,37 +2,208 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connecter votre chaudière Ökofen Pellematic",
-        "description": "Entrez l'URL de l'API JSON (ex: {example_url}). Le système découvrira automatiquement votre configuration.\n\n{charset_warning}",
+        "title": "Connexion à votre Ökofen Pellematic",
+        "description": "Saisissez l’URL de l’API JSON (par exemple {example_url}). Le système détectera automatiquement votre configuration.\n\n{charset_warning}",
         "data": {
-          "host": "URL de l'API JSON (mot de passe inclus)",
-          "name": "Nom de l'intégration",
+          "host": "URL de l’API JSON (mot de passe inclus)",
+          "name": "Nom de l’intégration",
           "charset": "Jeu de caractères (iso-8859-1 ou utf-8)",
           "old_firmware": "Mode ancien firmware (environ v3.10)"
         }
       },
       "reconfigure": {
         "title": "Reconfigurer Ökofen Pellematic",
-        "description": "Mettez à jour les paramètres d'intégration. Le nombre de composants est détecté automatiquement, vous n'avez qu'à configurer les paramètres de connexion.\n\nSi vous voyez des caractères corrompus (ü→Ã¼, ö→Ã¶) dans les noms d'entités, essayez de changer le jeu de caractères.\n\n⚠️ Après l'enregistrement, l'intégration sera rechargée et toutes les entités seront indisponibles pendant 1-2 minutes lors de la reconnexion à l'API.\n\n{charset_warning}",
+        "description": "Mettez à jour les paramètres de l’intégration. Le nombre de composants est détecté automatiquement ; seuls les paramètres de connexion doivent être configurés.\n\nSi des caractères incorrects apparaissent (ü→Ã¼, ö→Ã¶) dans les noms des entités, essayez de modifier le jeu de caractères.\n\n⚠️ Après l’enregistrement, l’intégration sera rechargée et toutes les entités seront indisponibles pendant 1 à 2 minutes, le temps de la reconnexion à l’API.\n\n{charset_warning}",
         "data": {
-          "host": "URL de l'API JSON (mot de passe inclus)",
-          "scan_interval": "Fréquence de rafraîchissement (secondes)",
+          "host": "URL de l’API JSON (mot de passe inclus)",
+          "scan_interval": "Intervalle d’interrogation (secondes)",
           "charset": "Jeu de caractères (iso-8859-1 ou utf-8)",
           "old_firmware": "Mode ancien firmware (environ v3.10)"
         }
       }
     },
     "error": {
-      "already_configured": "Appareil déjà configuré",
-      "cannot_connect": "Échec de connexion à l'API. Vérifiez l'URL et le mot de passe. Si l'URL est correcte, l'API Ökofen peut limiter les requêtes - veuillez patienter un moment et réessayer.",
-      "invalid_charset": "Encodage de caractères invalide. Utilisez un codec Python valide (ex: iso-8859-1, utf-8, windows-1252)"
+      "already_configured": "L’appareil est déjà configuré",
+      "cannot_connect": "Impossible de se connecter à l’API. Vérifiez l’URL et le mot de passe. Si l’URL est correcte, l’API Ökofen limite peut-être temporairement le nombre de requêtes ; patientez un instant puis réessayez.",
+      "invalid_charset": "Encodage de caractères non valide. Utilisez un codec Python valide (par exemple iso-8859-1, utf-8 ou windows-1252)"
     },
     "abort": {
-      "already_configured": "Appareil déjà configuré",
-      "reconfiguration_successful": "Configuration mise à jour avec succès. L'intégration se recharge - les entités seront disponibles dans 1-2 minutes."
+      "already_configured": "L’appareil est déjà configuré",
+      "reconfiguration_successful": "Configuration mise à jour avec succès. L’intégration est en cours de rechargement ; les entités seront de nouveau disponibles dans 1 à 2 minutes."
     }
   },
   "entity": {
+    "sensor": {
+      "system_ambient_temperature": {
+        "name": "Température ambiante"
+      },
+      "system_errors": {
+        "name": "Erreurs"
+      },
+      "system_usb_stick": {
+        "name": "Clé USB"
+      },
+      "system_boiler_temperature": {
+        "name": "Température chaudière"
+      },
+      "system_existing_boiler": {
+        "name": "Chaudière existante"
+      },
+      "system_mode": {
+        "name": "Mode système"
+      },
+      "weather_outside_temperature": {
+        "name": "Température extérieure"
+      },
+      "weather_cloudiness": {
+        "name": "Nébulosité"
+      },
+      "weather_forecast_temperature": {
+        "name": "Température prévue"
+      },
+      "weather_forecast_cloudiness": {
+        "name": "Nébulosité prévue"
+      },
+      "weather_forecast_today": {
+        "name": "Prévisions du jour"
+      },
+      "weather_start_time": {
+        "name": "Heure de début"
+      },
+      "weather_end_time": {
+        "name": "Heure de fin"
+      },
+      "weather_source": {
+        "name": "Source météo"
+      },
+      "weather_location": {
+        "name": "Localisation météo"
+      },
+      "weather_cloud_limit": {
+        "name": "Limite de nébulosité"
+      },
+      "weather_hysteresis": {
+        "name": "Hystérésis"
+      },
+      "weather_off_temperature": {
+        "name": "Température d’arrêt"
+      },
+      "weather_lead_time": {
+        "name": "Temps d’anticipation"
+      },
+      "weather_refresh": {
+        "name": "Actualisation"
+      },
+      "weather_eco_mode": {
+        "name": "Mode éco"
+      },
+      "hot_water_target_temperature": {
+        "name": "ECS {index} température de consigne"
+      },
+      "hot_water_on_temperature": {
+        "name": "ECS {index} température d’enclenchement"
+      },
+      "hot_water_off_temperature": {
+        "name": "ECS {index} température d’arrêt"
+      },
+      "hot_water_pump": {
+        "name": "ECS {index} pompe"
+      },
+      "hot_water_state": {
+        "name": "ECS {index} état"
+      },
+      "hot_water_status": {
+        "name": "ECS {index} statut"
+      },
+      "hot_water_time_program": {
+        "name": "ECS {index} programme horaire"
+      },
+      "hot_water_sensor_on": {
+        "name": "ECS {index} sonde d’enclenchement"
+      },
+      "hot_water_sensor_off": {
+        "name": "ECS {index} sonde d’arrêt"
+      },
+      "hot_water_mode": {
+        "name": "ECS {index} mode"
+      },
+      "hot_water_heat_once": {
+        "name": "ECS {index} chauffe unique"
+      },
+      "hot_water_min_temperature": {
+        "name": "ECS {index} température minimale"
+      },
+      "hot_water_max_temperature": {
+        "name": "ECS {index} température maximale"
+      },
+      "hot_water_smart_start": {
+        "name": "ECS {index} démarrage intelligent"
+      },
+      "hot_water_use_boiler_heat": {
+        "name": "ECS {index} utilisation de la chaleur chaudière"
+      },
+      "hot_water_eco_mode": {
+        "name": "ECS {index} mode éco"
+      },
+      "solar_collector_temperature": {
+        "name": "Solaire {index} température capteur"
+      },
+      "solar_storage_temperature": {
+        "name": "Solaire {index} température ballon"
+      },
+      "solar_pump": {
+        "name": "Solaire {index} pompe"
+      },
+      "solar_state": {
+        "name": "Solaire {index} état"
+      },
+      "solar_status": {
+        "name": "Solaire {index} statut"
+      },
+      "solar_mode": {
+        "name": "Solaire {index} mode"
+      },
+      "solar_cooling": {
+        "name": "Solaire {index} refroidissement"
+      },
+      "solar_storage_max_temperature": {
+        "name": "Solaire {index} température maximale ballon"
+      }
+    },
+    "binary_sensor": {
+      "hot_water_pump": {
+        "name": "ECS {index} pompe"
+      },
+      "solar_pump": {
+        "name": "Solaire {index} pompe"
+      }
+    },
+    "number": {
+      "weather_cloud_limit": {
+        "name": "Limite de nébulosité"
+      },
+      "weather_hysteresis": {
+        "name": "Hystérésis"
+      },
+      "weather_off_temperature": {
+        "name": "Température d’arrêt"
+      },
+      "weather_lead_time": {
+        "name": "Temps d’anticipation"
+      },
+      "hot_water_target_temperature": {
+        "name": "ECS {index} température de consigne"
+      },
+      "hot_water_min_temperature": {
+        "name": "ECS {index} température minimale"
+      },
+      "hot_water_max_temperature": {
+        "name": "ECS {index} température maximale"
+      },
+      "solar_storage_max_temperature": {
+        "name": "Solaire {index} température maximale ballon"
+      }
+    },
     "select": {
       "heater": {
         "state": {
@@ -46,7 +217,7 @@
         "state": {
           "0_off": "0 - Arrêt",
           "1_auto": "1 - Auto",
-          "2_force": "2 - Marche forcée",
+          "2_force": "2 - Forcé",
           "2_hotwater": "2 - Eau chaude"
         }
       },
@@ -55,6 +226,27 @@
           "0_off": "0 - Arrêt",
           "1_on": "1 - Marche"
         }
+      },
+      "hot_water_mode": {
+        "name": "ECS {index} mode"
+      },
+      "hot_water_heat_once": {
+        "name": "ECS {index} chauffe unique"
+      },
+      "hot_water_sensor_on": {
+        "name": "ECS {index} sonde d’enclenchement"
+      },
+      "hot_water_sensor_off": {
+        "name": "ECS {index} sonde d’arrêt"
+      },
+      "hot_water_eco_mode": {
+        "name": "ECS {index} mode éco"
+      },
+      "solar_mode": {
+        "name": "Solaire {index} mode"
+      },
+      "solar_cooling": {
+        "name": "Solaire {index} refroidissement"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary

This PR adds Home Assistant entity translations for dynamically discovered Ökofen Pellematic entities.

It adds translation keys and translation placeholders to dynamically generated entities while keeping the existing fallback behavior for unknown Ökofen API keys.

## Changes

- Add translation keys for dynamically discovered entities
- Add `{index}` translation placeholders for multiple hot water and solar components
- Add translated entity names for sensors, binary sensors, numbers and selects
- Update English translations
- Update French translations
- Preserve fallback entity names for unknown API keys
- Preserve existing unique IDs and entity IDs

## Testing

Tested on a real Ökofen Pellematic installation with Home Assistant.

Verified that:

- Home Assistant starts without integration or translation errors
- Dynamic entities are created correctly
- Hot water entities use indexed names such as `ECS 1 ...`
- Solar entities use indexed names such as `Solaire 1 ...`
- Existing manually renamed Home Assistant entities are preserved
- Unknown API keys continue to use the existing fallback naming

The integration was tested with Home Assistant configured to use UTF-8 for the Ökofen API character set.